### PR TITLE
Add support for decodePay

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ import Servant.API.Generic (fromServant)
 import Servant.Client (Client, ClientM)
 import Servant.Client.Generic (AsClientT, genericClient)
 
+import Lightning.Internal.Invoice (Bolt11)
 import Lightning.Node.Api (Api (_v1), ApiV1 (..))
 
 import qualified Lightning.Node.Api as L
@@ -63,6 +64,7 @@ _genInvoice :: L.InvoiceReq -> ClientM L.InvoiceRep
 _listInvoices :: Maybe L.InvoiceLabel -> ClientM L.ListInvoicesRep
 _listChannels :: ClientM [L.ListChannelsElem]
 _pay :: L.PayReq -> ClientM L.PayRep
+_decodePay :: Bolt11 -> ClientM L.DecodePayRep
 
 ApiV1
   { _getInfo
@@ -70,6 +72,7 @@ ApiV1
   , _listInvoices
   , _listChannels
   , _pay
+  , _decodePay
   } = fromServant @_ @(AsClientT ClientM) (_v1 api macaroon)
 ```
 
@@ -101,8 +104,9 @@ _genInvoice :: L.InvoiceReq -> ClientM L.InvoiceRep
 _listInvoices :: Maybe L.InvoiceLabel -> ClientM L.ListInvoicesRep
 _listChannels :: ClientM [L.ListChannelsElem]
 _pay :: L.PayReq -> ClientM L.PayRep
+_decodePay :: Bolt11 -> ClientM L.DecodePayRep
 
-_getInfo :<|> _genInvoice :<|> _listInvoices :<|> _listChannels :<|> _pay = api macaroon
+_getInfo :<|> _genInvoice :<|> _listInvoices :<|> _listChannels :<|> _pay :<|> _decodePay = api macaroon
 ```
 
 

--- a/example/client-generic/Main.hs
+++ b/example/client-generic/Main.hs
@@ -9,6 +9,7 @@ import Servant.Client (Client, ClientM)
 import Servant.Client.Generic (AsClientT, genericClient)
 
 import Authorization.Macaroon (Macaroon)
+import Lightning.Internal.Invoice (Bolt11)
 import Lightning.Node.Api (Api (_v1), ApiV1 (..))
 
 import qualified Lightning.Node.Api as L
@@ -29,12 +30,18 @@ api = genericClient
 
 _getInfo :: ClientM L.NodeInfo
 _genInvoice :: L.InvoiceReq -> ClientM L.InvoiceRep
+_listInvoices :: Maybe L.InvoiceLabel -> ClientM L.ListInvoicesRep
+_listChannels :: ClientM [L.ListChannelsElem]
 _pay :: L.PayReq -> ClientM L.PayRep
+_decodePay :: Bolt11 -> ClientM L.DecodePayRep
 
 ApiV1
   { _getInfo
   , _genInvoice
+  , _listInvoices
+  , _listChannels
   , _pay
+  , _decodePay
   } = fromServant @_ @(AsClientT ClientM) (_v1 api macaroon)
 
 

--- a/example/client-non-generic/Main.hs
+++ b/example/client-non-generic/Main.hs
@@ -12,6 +12,7 @@ import Servant.Client (Client, ClientM, client)
 import Lightning.Node.Api (Api)
 
 import Authorization.Macaroon (Macaroon)
+import Lightning.Internal.Invoice (Bolt11)
 import qualified Lightning.Node.Api as L
 
 
@@ -29,9 +30,12 @@ api = client (Proxy :: Proxy (ToServantApi Api))
 
 _getInfo :: ClientM L.NodeInfo
 _genInvoice :: L.InvoiceReq -> ClientM L.InvoiceRep
+_listInvoices :: Maybe L.InvoiceLabel -> ClientM L.ListInvoicesRep
+_listChannels :: ClientM [L.ListChannelsElem]
 _pay :: L.PayReq -> ClientM L.PayRep
+_decodePay :: Bolt11 -> ClientM L.DecodePayRep
 
-_getInfo :<|> _genInvoice :<|> _pay = api macaroon
+_getInfo :<|> _genInvoice :<|> _listInvoices :<|> _listChannels :<|> _pay :<|> _decodePay = api macaroon
 
 
 main :: IO ()

--- a/lightning-network.cabal
+++ b/lightning-network.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5a60ff226173c0bc2d5db3c98fc4a0b87e8c9ef0b34764c8c2882130dabac4d8
+-- hash: 90e365f77dce4a8bb446104e28f45a3ed62a618e370ef0ca6694faa104775e21
 
 name:           lightning-network
 version:        0.0.0.2
@@ -40,6 +40,7 @@ library
       Lightning.Node.Api.Invoice
       Lightning.Node.Api.Json
       Lightning.Node.Api.Pay
+      Lightning.Node.Api.Pay.Decode
   other-modules:
       Paths_lightning_network
   hs-source-dirs:
@@ -51,6 +52,7 @@ library
     , base64-bytestring >=0.1 && <1.1
     , bytestring >=0.9 && <0.11
     , containers >=0.5 && <0.7
+    , http-api-data
     , servant >=0.14 && <0.17
     , servant-auth >=0.3 && <0.4
     , servant-client-core >=0.14 && <0.17

--- a/package.yaml
+++ b/package.yaml
@@ -34,6 +34,7 @@ library:
     - aeson >= 1.3 && < 1.5
     - base64-bytestring >= 0.1 && < 1.1
     - containers >= 0.5 && < 0.7
+    - http-api-data
     - time >= 1.8 && < 1.11
     - servant >= 0.14 && < 0.17
     - servant-auth >= 0.3 && < 0.4

--- a/src/Lightning/Internal/Invoice.hs
+++ b/src/Lightning/Internal/Invoice.hs
@@ -15,7 +15,7 @@ import Data.Text (Text)
 import Data.Char (toLower)
 import Data.Aeson.TH (deriveJSON)
 import Data.Aeson.Types
-
+import Web.HttpApiData (ToHttpApiData)
 
 import GHC.Generics (Generic)
 
@@ -32,7 +32,7 @@ newtype Invoice = Invoice Bolt11
 --
 -- TODO: Provide FromJSON instance that checks the format.
 newtype Bolt11 = Bolt11 Text
-  deriving (FromJSON, Show, ToJSON)
+  deriving (FromJSON, Show, ToJSON, ToHttpApiData)
 
 -- | Encode an 'Invoice' as bolt11.
 --

--- a/src/Lightning/Node/Api.hs
+++ b/src/Lightning/Node/Api.hs
@@ -13,14 +13,16 @@ module Lightning.Node.Api
   ) where
 
 import GHC.Generics (Generic)
-import Servant.API ((:>), Get, JSON, Post, QueryParam, ReqBody)
+import Servant.API ((:>), Capture, Get, JSON, Post, QueryParam, ReqBody)
 import Servant.API.Generic (ToServantApi, (:-))
 import Servant.Auth (Auth)
 
 import Authorization.Macaroon (Macaroon)
+import Lightning.Internal.Invoice (Bolt11)
 import Lightning.Node.Api.GetInfo as A (Address (..), NodeInfo (..))
 import Lightning.Node.Api.Invoice as A (InvoiceLabel(..), InvoiceRep (..), InvoiceReq (..), ListInvoicesRep (..))
 import Lightning.Node.Api.Pay as A (PayReq (..), PayRep (..))
+import Lightning.Node.Api.Pay.Decode as A (DecodePayRep (..), Route (..))
 import Lightning.Node.Api.Channel as A (ListChannelsElem (..))
 
 
@@ -46,6 +48,11 @@ data ApiV1 route = ApiV1
       :- "pay"
       :> ReqBody '[JSON] PayReq
       :> Post '[JSON] PayRep
+  , _decodePay :: route
+      :- "pay"
+      :> "decodePay"
+      :> Capture "invoice" Bolt11
+      :> Get '[JSON] DecodePayRep
   }
   deriving (Generic)
 

--- a/src/Lightning/Node/Api/Pay/Decode.hs
+++ b/src/Lightning/Node/Api/Pay/Decode.hs
@@ -1,0 +1,53 @@
+-- SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+-- | Route: @/pay/decodePay/<invoice>/@
+module Lightning.Node.Api.Pay.Decode
+  ( DecodePayRep (..)
+  , Route (..)
+  ) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToEncoding, genericToJSON)
+import Data.Time.Clock.POSIX (POSIXTime)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Lightning (Bolt11, MilliSatoshi)
+import Lightning.Node.Api.Json (lightningOptions)
+
+
+-- | Reply with a decoded invoice information.
+data DecodePayRep = DecodePayRep
+  { drpCurrency           :: Text
+  , drpCreatedAt          :: POSIXTime
+  , drpExpiry             :: Maybe Int -- ^ Expire after (seconds).
+  , drpPayee              :: Text
+  , drpMsatoshi           :: Maybe MilliSatoshi  -- ^ Amount requested
+  , drpDescription        :: Text
+  , drpMinFinalCltvExpiry :: Maybe Int
+  , drpPaymentSecret      :: Maybe Text
+  , dprFeatures           :: Maybe Text
+  , dprRoutes             :: Maybe [Route]
+  , dprPaymentHash        :: Text
+  , drpSignature          :: Text
+  }
+  deriving (Generic, Show)
+
+instance ToJSON DecodePayRep where
+  toJSON = genericToJSON lightningOptions
+  toEncoding = genericToEncoding lightningOptions
+
+instance FromJSON DecodePayRep where
+  parseJSON = genericParseJSON lightningOptions
+
+
+newtype Route = Route { rtDescription :: Text }
+  deriving (Generic, Show)
+
+instance ToJSON Route where
+  toJSON = genericToJSON lightningOptions
+  toEncoding = genericToEncoding lightningOptions
+
+instance FromJSON Route where
+  parseJSON = genericParseJSON lightningOptions


### PR DESCRIPTION
Adds support for the the [decodepay](https://lightning.readthedocs.io/lightning-decodepay.7.html) functionality of `c-lightning`, under `/pay/decodePay/<invoice>/`