### PR TITLE
[NC-129] add support Token-based authentication

### DIFF
--- a/lightning-network.cabal
+++ b/lightning-network.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 90e365f77dce4a8bb446104e28f45a3ed62a618e370ef0ca6694faa104775e21
+-- hash: 7cf5a15c44125baf35432af8b41d82e8d66785c5308bd4b88085b8cbda64d01f
 
 name:           lightning-network
 version:        0.0.0.2
@@ -54,6 +54,7 @@ library
     , bytestring >=0.9 && <0.11
     , containers >=0.5 && <0.7
     , http-api-data
+    , http-types
     , servant >=0.14 && <0.17
     , servant-auth >=0.3 && <0.4
     , servant-client-core >=0.14 && <0.17

--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ library:
     - base64-bytestring >= 0.1 && < 1.1
     - containers >= 0.5 && < 0.7
     - http-api-data
+    - http-types
     - time >= 1.8 && < 1.11
     - servant >= 0.14 && < 0.17
     - servant-auth >= 0.3 && < 0.4

--- a/src/Authorization/Macaroon.hs
+++ b/src/Authorization/Macaroon.hs
@@ -5,19 +5,31 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- | Lightning REST API macaroon-based authorization.
+-- | Lightning REST API 'Macaroon' authorization.
+--
+-- Note: to support both 'Macaroon'-based and 'Token'-based authorization, this
+-- module exports copies of 'Token' and 'Bearer' from 'Servant.Auth.Client'.
+-- This is necessary because there is no way to extend the 'HasClient' instance
+-- of 'Servant.Auth.Client' otherwise.
 module Authorization.Macaroon
   ( Macaroon
   , load
-  ) where
 
+    -- * Servant Auth Client
+  , Token (..)
+  , Bearer
+  ) where
 
 import Data.ByteString (ByteString)
 import Data.Kind (Constraint)
 import Data.Proxy (Proxy (Proxy))
 import Data.Sequence ((<|))
+import Data.String (IsString)
+import GHC.Generics (Generic)
+import qualified GHC.TypeLits as Lit
+import Network.HTTP.Types.Header (Header)
 import Servant.API ((:>))
-import Servant.Auth (Auth)
+import Servant.Auth (Auth, JWT)
 import Servant.Client.Core (Client, HasClient (..), RequestF (requestHeaders))
 
 import qualified Data.ByteString as BS
@@ -29,28 +41,80 @@ newtype Macaroon = Macaroon ByteString
 load :: FilePath -> IO Macaroon
 load = (Macaroon <$>) . BS.readFile
 
+--------------------------------------------------------------------------------
+-- Servant Auth Client
+--------------------------------------------------------------------------------
 
--- * Servant Auth
+-- | A simple bearer token.
+--
+-- Note: this is identical to the one used in 'Servant.Auth.Client' and can be
+-- used to replace it.
+newtype Token = Token { getToken :: ByteString }
+  deriving (Eq, Show, Read, Generic, IsString)
 
-type family HasMacaroon xs :: Constraint where
-  HasMacaroon (Macaroon ': xs) = ()
-  HasMacaroon (x ': xs) = HasMacaroon xs
-  HasMacaroon '[] = MacaroonAuthNotEnabled
+-- * Authentication combinators
 
-class MacaroonAuthNotEnabled
+-- | A Bearer token in the Authorization header:
+--
+--    @Authorization: Bearer <token>@
+--
+-- This can be any token recognized by the server, for example,
+-- a JSON Web Token (JWT).
+--
+-- Note that, since the exact way the token is validated is not specified,
+-- this combinator can only be used in the client. The server would not know
+-- how to validate it, while the client does not care.
+-- If you want to implement Bearer authentication in your server, you have to
+-- choose a specific combinator, such as 'JWT'.
+--
+-- Note: this is identical to the one used in 'Servant.Auth.Client' and can be
+-- used to replace it.
+data Bearer
 
-instance
-  (HasMacaroon auths, HasClient m api)
+--------------------------------------------------------------------------------
+-- Servant Auth Client Machinery
+--------------------------------------------------------------------------------
+
+instance (HasAuthClient auths, HasClient m api)
   => HasClient m (Auth auths a :> api) where
-    type Client m (Auth auths a :> api) = Macaroon -> Client m api
+    type Client m (Auth auths a :> api) = ClientAuthData auths -> Client m api
 
-    clientWithRoute m _ req (Macaroon bytes) =
+    clientWithRoute m _ req authData =
       clientWithRoute m (Proxy :: Proxy api) $
         req
           { requestHeaders =
-              ("macaroon", B64.encode bytes) <| requestHeaders req
+              clientAuthHeader (Proxy @auths) authData <| requestHeaders req
           }
 
 #if MIN_VERSION_servant_client_core(0,14,0)
     hoistClientMonad pm _ nt cl = hoistClientMonad pm (Proxy :: Proxy api) nt . cl
 #endif
+
+-- | Type family that allows to use 'Macaroon' or 'Token' depending on which is
+-- found first in the @auth@ list.
+type family ClientAuthData xs where
+  ClientAuthData (Macaroon ': xs) = Macaroon
+  ClientAuthData (Bearer ': xs)   = Token
+  ClientAuthData (JWT ': xs)      = Token
+  ClientAuthData (x ': xs)        = ClientAuthData xs
+  ClientAuthData '[] = Lit.TypeError (Lit.Text "No known client auth header.")
+
+-- | Supporting typeclass to 'HasClient', this allows for the different 'Header'
+-- used by 'Macaroon' and 'Token' (with 'ClientAuthData').
+class HasAuthClient (auths :: [*]) where
+  clientAuthHeader :: Proxy auths -> ClientAuthData auths -> Header
+
+instance {-# OVERLAPPING #-} HasAuthClient (Macaroon ': xs) where
+  clientAuthHeader _ (Macaroon bytes) = ("macaroon", B64.encode bytes)
+
+instance {-# OVERLAPPING #-} HasAuthClient (Bearer ': xs) where
+  clientAuthHeader _ (Token token) = ("Authorization", "Bearer " <> token)
+
+instance {-# OVERLAPPING #-} HasAuthClient (JWT ': xs) where
+  clientAuthHeader _ (Token token) = ("Authorization", "Bearer " <> token)
+
+instance {-# OVERLAPPABLE #-}
+  (HasAuthClient xs, ClientAuthData xs ~ ClientAuthData (x ': xs))
+  => HasAuthClient (x ': xs) where
+  clientAuthHeader _ = clientAuthHeader (Proxy @xs)
+


### PR DESCRIPTION
Problem: the HasClient instance for Macaroon conflicts with the one
in Servant.Auth.Client.
The instance is implicitly exported by other modules (most notably:
Lightning.Node.Api) and as a result it's not possible to make a
servant client for a service that uses this library and has a
different authentication method (e.g. JWT).

Solution: add an implementation of 'HasClient' that supports both
Token-based and Macaroon-based authentication.
Additionally exports copies of Token and Bearer in order to cover
the functionality of Servant.Auth.Client
